### PR TITLE
Started the bot coordinator 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Discord Bot token https://discord.com/developers/applications
 DISCORD_BOT_TOKEN=
+COORDINATOR_BOT_TOKEN=
 
 LOGGING=True
 REPLYING_ALL=False

--- a/Dockerfile.coordinator
+++ b/Dockerfile.coordinator
@@ -1,0 +1,14 @@
+FROM python:3.10.2-slim
+
+ENV PYTHONUNBUFFERED 1
+WORKDIR /DiscordBot
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN rm main.py && mv coordinator_main.py main.py
+
+RUN useradd -m discordbot && chown -R discordbot:discordbot /DiscordBot
+USER discordbot
+
+CMD ["python3", "main.py"]

--- a/coordinator_main.py
+++ b/coordinator_main.py
@@ -1,0 +1,8 @@
+import os
+
+from src import coordinator
+from dotenv import load_dotenv
+
+
+if __name__ == '__main__':
+    coordinator.run_discord_bot()

--- a/docker-compose.instructor.yml
+++ b/docker-compose.instructor.yml
@@ -1,0 +1,9 @@
+services:
+  coordinator-bot:
+    build:
+      context: .
+      dockerfile: Dockerfile.coordinator
+    image: chatbot-coordinator
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/src/bclient.py
+++ b/src/bclient.py
@@ -1,0 +1,50 @@
+import os
+import discord
+import asyncio
+from discord import app_commands
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class DiscordClient(discord.Client):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(intents=intents)
+        self.tree = app_commands.CommandTree(self)
+        self.message_queue = asyncio.Queue()
+        self.current_channel = None
+        self.activity = discord.Activity(
+            type=discord.ActivityType.listening,
+            name="/start | /register | /help"
+        )
+
+    async def on_ready(self):
+        await self.tree.sync()
+        print(f"{self.user} is now running!")
+
+    async def process_messages(self):
+        while True:
+            if self.current_channel is not None:
+                while not self.message_queue.empty():
+                    async with self.current_channel.typing():
+                        message, user_message = await self.message_queue.get()
+                        try:
+                            # Simulate processing the message
+                            await self.send_message(message, user_message)
+                        except Exception as e:
+                            print(f"Error while processing message: {e}")
+                        finally:
+                            self.message_queue.task_done()
+            await asyncio.sleep(1)
+
+    async def enqueue_message(self, message, user_message):
+        await self.message_queue.put((message, user_message))
+
+    async def send_message(self, message, user_message):
+        try:
+            # Simulate chatbot response
+            response = f"Chatbot response to: {user_message}"
+            await message.channel.send(response)
+        except Exception as e:
+            print(f"Error while sending message: {e}")

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -1,0 +1,46 @@
+import os
+import asyncio
+from src.log import logger  # Assuming you have a logger utility
+from discord import app_commands
+from src.bclient import DiscordClient
+
+def run_discord_bot():
+    # Create an instance of DiscordClient
+    discord_client = DiscordClient()
+
+    # A queue to hold registered chatbots
+    chatbot_queue = []
+
+    @discord_client.tree.command(name="register", description="Register a chatbot")
+    @app_commands.describe(bot_name="Name of the chatbot to register")
+    async def register_chatbot(interaction, bot_name: str):
+        if bot_name.lower() not in chatbot_queue:
+            chatbot_queue.append(bot_name.lower())
+            await interaction.response.send_message(f"{bot_name} has been registered.")
+        else:
+            await interaction.response.send_message(f"{bot_name} is already registered.")
+
+    @discord_client.tree.command(name="start", description="Start chatbot interaction")
+    @app_commands.describe(question="The question to ask the first bot")
+    async def start_chat(interaction, question: str):
+        if not chatbot_queue:
+            await interaction.response.send_message("No chatbots are registered in the queue.")
+            return
+
+        current_input = question
+        await interaction.response.defer(ephemeral=False)  # Acknowledge the command
+
+        for bot_name in chatbot_queue:
+            try:
+                # Simulate chatbot response
+                response = f"{bot_name.capitalize()} '{current_input}'"
+                await interaction.followup.send(response)
+                current_input = response  # Pass the response to the next bot
+            except Exception as e:
+                await interaction.followup.send(f"Error interacting with {bot_name}: {e}")
+                break
+
+        # await interaction.followup.send("Interaction complete.")
+
+    TOKEN = os.getenv("COORDINATOR_BOT_TOKEN")
+    discord_client.run(TOKEN)


### PR DESCRIPTION
There should be a queue of bots with a question asked. Each subsequent answer should be asked to the following bot in the queue... it doesn't really work. Additionally slash commands are inaccessible by bots so we need a way to send to the bots via their @... I'm not sure if that is allowed either...

To run the bot and the coordinator use 
```
docker compose -f docker-compose.yml -f docker-compose.instructor.yml up --build
```

This command adds another Docker container of a Discord bot coordinator alongside the Chatbot Docker container. 
Make sure to have a `DISCORD_BOT_TOKEN` and `COORDINATOR_BOT_TOKEN` set in your `.env` to two separate discord bots. 

My current thought for a solution would be to use simple text parsing for "@" and the bots user name and use the `/replyAll` feature so all the bots are always listening all of the time. That way the coordinator just has to @ each bot.
